### PR TITLE
fix: add self to connect and data to default src directives

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,8 +62,8 @@ function sharedConfig(prefix) {
     helmet: {
       contentSecurityPolicy: {
         directives: {
-          defaultSrc: ["'self'"],
-          connectSrc: ['ws://localhost:*', 'localhost:*', 'data:'],
+          defaultSrc: ["'self'", 'data:'],
+          connectSrc: ["'self'", 'ws://localhost:*', 'localhost:*', 'data:'],
           fontSrc: ["'self'", 'data:', 'fonts.gstatic.com', 'cdn.jsdelivr.net'],
           imgSrc: ["'self'", 'data:'],
           styleSrc: ["'self'", "'unsafe-inline'", 'cdn.jsdelivr.net'],


### PR DESCRIPTION
- add `self` to connect-src
- add `data:` to default-src