### PR TITLE
fix: mongoose deprecation warning `findOneAndUpdate()` and `findOneAndDelete()` without the `useFindAndModify` option set to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,8 @@ function sharedConfig(prefix) {
             ? parseInt(process.env[`${prefix}_MONGO_RECONNECT_INTERVAL`], 10)
             : 1000,
           useNewUrlParser: true,
-          useUnifiedTopology: true
+          useUnifiedTopology: true,
+          useFindAndModify: false
         }
       }
     },


### PR DESCRIPTION
Fix DeprecationWarning: Mongoose: `findOneAndUpdate()` and `findOneAndDelete()` without the `useFindAndModify` option set to false are deprecated
https://github.com/ladjs/lad/issues/408